### PR TITLE
Implementing the h2 database

### DIFF
--- a/onlinebookstore/pom.xml
+++ b/onlinebookstore/pom.xml
@@ -44,6 +44,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/onlinebookstore/src/main/resources/application-dev.properties
+++ b/onlinebookstore/src/main/resources/application-dev.properties
@@ -1,0 +1,11 @@
+spring.application.name=dev
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=true
+
+#http://localhost:8080/h2-console/

--- a/onlinebookstore/src/main/resources/application-prod.properties
+++ b/onlinebookstore/src/main/resources/application-prod.properties
@@ -1,0 +1,10 @@
+spring.application.name=prod
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/springbootapps?useSSL=false&useUnicode=yes&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=root
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+spring.data.rest.base-path=/api/v1

--- a/onlinebookstore/src/main/resources/application.properties
+++ b/onlinebookstore/src/main/resources/application.properties
@@ -1,9 +1,1 @@
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/springbootapps?useSSL=false&useUnicode=yes&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=root
-
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
-
-spring.data.rest.base-path=/api/v1
+spring.profiles.active=dev


### PR DESCRIPTION
I'm implementing the h2 database which is easier to configure and works at compile time and helps a lot as a development environment.
To access the h2 database: [http://localhost:8080/h2-console/](url)
To change the environment from  dev(h2) to prod(MySql) just go to application.properties :

```
spring.profiles.active=prod
```

and change to:

```
spring.profiles.active=dev
```